### PR TITLE
Enable some new options from eslint-plugin-react v7.12

### DIFF
--- a/lib/rules/react.js
+++ b/lib/rules/react.js
@@ -16,8 +16,14 @@ module.exports = {
     // restrict file extensions that may contain JSX
     'react/jsx-filename-extension': ['error', { extensions: ['.js', '.mjs'] }],
 
+    // enforce shorthand or standard form for React fragments
+    'react/jsx-fragments': 'error',
+
     // enforce event handler naming conventions in JSX
     'react/jsx-handler-names': 'error',
+
+    // validate JSX indentation
+    'react/jsx-indent': ['error', 2, { checkAttributes: true }],
 
     // validate JSX has key prop when in array or iterator
     'react/jsx-key': 'error',
@@ -34,6 +40,9 @@ module.exports = {
 
     // prevent direct mutation of `this.state`
     'react/no-direct-mutation-state': 'error',
+
+    // prevent common casing typos
+    'react/no-typos': 'error',
 
     // enforce component methods order
     'react/sort-comp': ['error', {


### PR DESCRIPTION
- [react/jsx-fragments](https://github.com/yannickcr/eslint-plugin-react/blob/v7.12.0/docs/rules/jsx-fragments.md): Enforce shorthand form (`<>...</>`) for React fragments
- [react/jsx-indent](https://github.com/yannickcr/eslint-plugin-react/blob/v7.12.0/docs/rules/jsx-indent.md): Validate JSX indentation
- [react/no-typos](https://github.com/yannickcr/eslint-plugin-react/blob/v7.12.0/docs/rules/no-typos.md): Prevent common casing typos