### PR TITLE
Add in React as a dev dependency to fix the package not installed warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "eslint": "^5.9.0",
     "eslint-plugin-jest": "^22.1.0",
     "eslint-plugin-node": "^8.0.0",
-    "jest": "^23.6.0"
+    "jest": "^23.6.0",
+    "react": "^16.7.0"
   },
   "peerDependencies": {
     "eslint": "^5.9.0"


### PR DESCRIPTION
Currently, on Travis CI we get the following warning:

```
console.error node_modules/eslint-plugin-react/lib/util/error.js:10
    Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.
```

This PR just fixes that warning by including React as a dev dependency.